### PR TITLE
Harden globMatch to handle dot files

### DIFF
--- a/src/matching.ts
+++ b/src/matching.ts
@@ -32,7 +32,7 @@ export function globMatch(pattern: string, input: string): boolean {
 		input = home + input.slice(1);
 	}
 
-	return minimatch(input, pattern);
+	return minimatch(input, pattern, { dot: true });
 }
 
 /**

--- a/test/matching.test.ts
+++ b/test/matching.test.ts
@@ -58,6 +58,7 @@ test("globMatch", async (t) => {
 	await t.test("* matches anything except /", () => {
 		assert.equal(globMatch("*.ts", "test.ts"), true);
 		assert.equal(globMatch("*.ts", "src/test.ts"), false);
+		assert.equal(globMatch("*.env", ".env"), true);
 		assert.equal(globMatch("test/*", "test/foo.ts"), true);
 		assert.equal(globMatch("test/*", "test/sub/foo.ts"), false);
 	});
@@ -67,6 +68,7 @@ test("globMatch", async (t) => {
 		assert.equal(globMatch("**/*.ts", "test.ts"), true);
 		assert.equal(globMatch("**/*.ts", "src/test.ts"), true);
 		assert.equal(globMatch("**/*.ts", "src/sub/test.ts"), true);
+		assert.equal(globMatch("**/*.key", ".ssh/.hidden/priv.key"), true);
 	});
 
 	await t.test("? matches single character", () => {


### PR DESCRIPTION
`globMatch` was calling minimatch in a way that wasn't matching dot files. This PR sets `dot: true` to address that:

> #### dot
> 
> Allow patterns to match filenames starting with a period, even if the pattern does not explicitly have a period in that spot.
> 
> Note that by default, `a/**/b` will **not** match `a/.d/b`, unless `dot` is set.
> 
> [minimatch docs](https://www.npmjs.com/package/minimatch#user-content-options))

This also handles patterns like `**/*.key` which would match `a/priv.key` but not `.hidden/priv.key`

## Before

`globMatch('*.env', '.env')` → `false`

(using the default guard rules)

[screencast](https://github.com/user-attachments/assets/e89fefd5-91a3-44f7-8d16-2d14c1217187)

## After

`globMatch('*.env', '.env')` → `true`

[screencast](https://github.com/user-attachments/assets/e7f7bca3-853f-45d7-b659-d11fb19bcbb3)
