### PR TITLE
Update default rules to match .env and .pem in nested directories too

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Configure in `~/.pi/agent/settings.json`:
       },
       "read": {
         "*": "allow",
-        "*.env": "deny",
-        "*.pem": "deny"
+        "**/*.env": "deny",
+        "**/*.pem": "deny"
       },
       "write": { "*": "ask" },
       "edit": { "*": "ask" },

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -75,8 +75,8 @@ export const DEFAULT_CONFIG = {
 		},
 		read: {
 			"*": "allow",
-			"*.env": "deny",
-			"*.pem": "deny",
+			"**/*.env": "deny",
+			"**/*.pem": "deny",
 		},
 		write: {
 			"*": "ask",


### PR DESCRIPTION
Changes default rules for read denies
* `*.env` → `**/*.env`
* `*.pem` → `**/*.pem`

So that nested files are also matched.

## Alternatives considered

### Set `matchBase: true` in minimatch

Using [`matchBase: true`](https://www.npmjs.com/package/minimatch#user-content-options) would make all non-absolute patterns match in nested subdirectories too. For example:
* `*.ts` would match `foo.ts` but also `test/foo.ts`
* `/project/*.ts` would still only match `/project/foo.ts` but not `/project/test/foo.ts`

From the tests in [`matching.test.ts`](https://github.com/jdiamond/pi-guard/blob/eee7dc2f41b23f3ff7d9f60c2dd09d219fee76e7/test/matching.test.ts) it seems this was a deliberate design choice and that users are expected to use `**/` as prefix to achieve that.

@jdiamond let me know if you prefer this alternative